### PR TITLE
Document `just docs` usage and Bashly guidance in README and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,12 @@ From the repo README snippet:
 - Run `setup.sh` for needed libraries
 - `just build` generates a local version in `target/lct`
 - `make install` installs the local version
+- `just docs` regenerates usage documentation in `docs/`
 - `just release` creates a new release :contentReference[oaicite:3]{index=3}
+
+CLI structure note:
+
+- LCT is built with [Bashly](https://bashly.dev/), which defines the CLI structure and help text. Use the Bashly source-of-truth definitions (e.g., in `src/`) and then regenerate output via `just build` (for the executable) and `just docs` (for usage docs) rather than editing generated artifacts by hand.
 
 ## 2) How to work (agent workflow)
 
@@ -69,6 +74,7 @@ Run the standard build/install flow for any meaningful change:
 
 - `./setup.sh` (if dependencies changed)
 - `just build`
+- `just docs` (if CLI help/usage text changes)
 - `make install`
 - Smoke test the CLI locally (see section 8)
 

--- a/README.md
+++ b/README.md
@@ -16,4 +16,5 @@ Needed Libraries
 - run `setup.sh` to get necessary libraries
 - `just build` to generate local version in target/lct
 - `make install` to install local version
+- `just docs` to regenerate usage documentation
 - `just release` to generate new release


### PR DESCRIPTION
### Motivation
- Make it explicit that usage documentation is regenerated with `just docs` and explain that Bashly is the CLI source-of-truth so agents do not edit generated artifacts directly.

### Description
- Add `just docs` to the README contributing checklist and update `AGENTS.md` to mention `just docs`, link to `https://bashly.dev/`, and advise using `just build` (for the executable) and `just docs` (for usage docs) instead of hand-editing generated files.

### Testing
- No automated tests were run because this is a docs-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987565622808328b4169181173e4c65)