### PR TITLE
Replace pv with gum spinner in prune

### DIFF
--- a/src/commands/prune.sh
+++ b/src/commands/prune.sh
@@ -84,13 +84,15 @@ else
   if [[ ${#directories_to_prune[@]} -eq 0 ]]; then
     echo "No directories to prune."
   else
-    printf '%s\n' "${directories_to_prune[@]}" |
-      sort -r |
-      while IFS= read -r dir; do
-        rm -rf -- "$dir"
-        printf '.\n'
-      done |
-      pv -l -s "${#directories_to_prune[@]}" >/dev/null
+    prune_directories() {
+      printf '%s\n' "${directories_to_prune[@]}" |
+        sort -r |
+        while IFS= read -r dir; do
+          rm -rf -- "$dir"
+        done
+    }
+
+    gum_spinner "Pruning directories" prune_directories
     echo "Pruning complete."
   fi
 fi


### PR DESCRIPTION
### Motivation
- Remove the `pv` dependency and unify UX by using the repository's existing `gum_spinner` helper for progress display in the `prune` command.
- Keep behavior stable and predictable while simplifying the implementation and avoiding an external progress tool.

### Description
- Replaced the `pv`-based progress pipeline in `src/commands/prune.sh` with a `prune_directories` function that performs the `rm -rf` loop and is invoked via `gum_spinner`.
- Kept the reverse sort and removal semantics intact and reused the existing `gum_spinner` UI helper from `src/lib/ui_helpers.sh`.
- No other behavioral changes to dry-run handling or directory selection logic.

### Testing
- Ran `just build` which completed successfully and produced the build artifact.
- Ran `just test` which returned `OK` and the smoke tests reported `Overall result: SUCCESS`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69881d9a1024832899e84b78e5d1f11e)