### PR TITLE
Add GitHub Actions release workflow and adapt release script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Dependencies
+        uses: jdx/mise-action@v3
+
+      - name: Build
+        run: just build
+
+      - name: Prepare release artifacts
+        run: ./scripts/release.sh
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: target/release/release-notes.md
+          files: |
+            target/release/*.zip
+            target/release/*.tar.gz

--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@
 - `just build` to generate local version in target/build/lct
 - `just test` to run the smoke tests (uses bash_unit)
 - `just install` to install local version (target/build/lct) to /usr/local/bin
-- `just release <major|minor|patch>` to generate new release
+- `just release <major|minor|patch>` to prepare release artifacts, then push the new tag to trigger the GitHub Action release


### PR DESCRIPTION
### Motivation

- Move release publication into CI so releases are created from pushed tags using a maintained action rather than requiring local `gh` calls.
- Produce deterministic release artifacts/notes locally so the GitHub Action can consume them and create the release.

### Description

- Add a new workflow `.github/workflows/release.yml` that triggers on `push` of `v*` tags and uses `softprops/action-gh-release` to publish the release.
- Update `scripts/release.sh` to generate `target/release/release-notes.md`, create `target/release/*.zip` and `*.tar.gz`, and stop calling `gh release` directly, while improving tag detection for generating changelogs.
- Update `README.md` to document the new flow where `just release` prepares artifacts and maintainers push the new tag to trigger the Action.

### Testing

- Ran `just build` which completed successfully and produced `target/build/lct` as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988fb8e59a48328a84e149e80670a24)