### PR TITLE
Avoid eval when launching editor in config command

### DIFF
--- a/src/commands/config.sh
+++ b/src/commands/config.sh
@@ -11,10 +11,17 @@ for ext in $exts; do
   candidates+=("$CONFIG_DIR/$lib_name.$ext") # Sometimes config is at ~/.config/libname.ext
 done
 
+if [[ -n ${EDITOR:-} ]]; then
+  read -r -a editor_cmd <<<"$EDITOR"
+fi
+if (( ${#editor_cmd[@]:-0} == 0 )); then
+  editor_cmd=("vi")
+fi
+
 # Find the first existing config file
 for path in "${candidates[@]}"; do
   if [ -f "$path" ]; then
-    eval "$EDITOR \"$path\""
+    "${editor_cmd[@]}" "$path"
     exit 0
   fi
 done
@@ -22,7 +29,7 @@ done
 if gum_available; then
   picked_path=$(gum_pick_file "$CONFIG_DIR" --file)
   if [[ -n "$picked_path" ]]; then
-    eval "$EDITOR \"$picked_path\""
+    "${editor_cmd[@]}" "$picked_path"
     exit 0
   fi
 fi


### PR DESCRIPTION
### Motivation
- Remove the use of `eval` when launching the editor to prevent command injection and ensure file paths remain safely quoted while preserving prior behavior and providing a fallback editor when `EDITOR` is unset.

### Description
- Parse `EDITOR` into an array with `read -r -a editor_cmd <<<"$EDITOR"` and default to `editor_cmd=("vi")` when empty, and replace `eval "$EDITOR \"$path\""` with `"${editor_cmd[@]}" "$path"` for both candidate paths and `gum`-picked paths.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a6cdca7b08328a7c0175500634889)