### PR TITLE
Remove automatic dev install from Codex environment setup

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -7,7 +7,6 @@ script = '''
 set -euo pipefail
 
 ./scripts/setup.sh
-mise run dev
 '''
 
 [cleanup]


### PR DESCRIPTION
## Summary
- Stop running `mise run dev` as part of the Codex environment bootstrap.
- Keep setup limited to the canonical `./scripts/setup.sh` flow so worktree initialization stays predictable and avoids extra side effects.

## Testing
- Not run (not requested)