### PR TITLE
Add registry-driven package manager metadata

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -145,3 +145,25 @@ The user config file at ~/.config/lct/config.yaml should conform to the LCT conf
       - modules
       - secrets
     packageManager: mise
+
+## Package-manager model
+
+LCT keeps package-manager metadata in an internal registry. The registry
+distinguishes **system**, **runtime**, and **language** managers, records typed
+dependencies such as **runtime:node**, and marks unavailable bundle operations
+as **unsupported**.
+
+| Manager | Category | Dependencies | Install/remove | Bundle export/restore |
+| --- | --- | --- | --- | --- |
+| **brew** | system | none | supported | supported |
+| **apt** | system | none | supported | supported |
+| **mise** | runtime | none | supported | supported |
+| **pnpm** | language | **runtime:node** | supported | unsupported |
+| **cargo** | language | **runtime:rust** | supported | unsupported |
+| **pip** | language | **runtime:python** | supported | supported |
+| **uv** | language | none | supported | unsupported |
+
+To add a manager, add one registry record, implement any supported operation
+handlers in **src/lib/package_manager.sh**, and extend the registry tests and
+this table. Registry operation fields are handler identifiers and are never
+evaluated as shell input.

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -72,3 +72,31 @@ bootstrap_order:
 
 A custom order must include every supported phase exactly once. LCT validates the
 list and prints the resolved order before running any phase.
+
+## Package-manager model
+
+`packageManager` selects the preferred manager for package gather and bootstrap
+flows. Internally, LCT models managers in a registry with three categories:
+
+- `system` — top-level operating-system package managers such as `brew` and `apt`.
+- `runtime` — runtime/toolchain managers such as `mise`.
+- `language` — language ecosystem managers such as `pnpm`, `cargo`, `pip`, and `uv`.
+
+Dependencies use typed identifiers such as `runtime:node`, `runtime:rust`, and
+`runtime:python`. Unsupported bundle export or restore operations are recorded
+explicitly instead of being inferred from a missing implementation.
+
+| Manager | Category | Dependencies | Install/remove | Bundle export/restore |
+| --- | --- | --- | --- | --- |
+| `brew` | system | none | supported | supported |
+| `apt` | system | none | supported | supported |
+| `mise` | runtime | none | supported | supported |
+| `pnpm` | language | `runtime:node` | supported | unsupported |
+| `cargo` | language | `runtime:rust` | supported | unsupported |
+| `pip` | language | `runtime:python` | supported | supported |
+| `uv` | language | none | supported | unsupported |
+
+To add a manager, add a record to `src/lib/package_manager_registry.sh`, add the
+corresponding operation handlers to `src/lib/package_manager.sh`, and extend the
+registry tests and this table. Operation handler identifiers are dispatched by
+LCT and are never evaluated as shell input.

--- a/src/bashly.yml
+++ b/src/bashly.yml
@@ -74,6 +74,28 @@ x_markdown_footer: |-
         - modules
         - secrets
       packageManager: mise
+
+  ## Package-manager model
+
+  LCT keeps package-manager metadata in an internal registry. The registry
+  distinguishes `system`, `runtime`, and `language` managers, records typed
+  dependencies such as `runtime:node`, and marks unavailable bundle operations
+  as `unsupported`.
+
+  | Manager | Category | Dependencies | Install/remove | Bundle export/restore |
+  | --- | --- | --- | --- | --- |
+  | `brew` | system | none | supported | supported |
+  | `apt` | system | none | supported | supported |
+  | `mise` | runtime | none | supported | supported |
+  | `pnpm` | language | `runtime:node` | supported | unsupported |
+  | `cargo` | language | `runtime:rust` | supported | unsupported |
+  | `pip` | language | `runtime:python` | supported | supported |
+  | `uv` | language | none | supported | unsupported |
+
+  To add a manager, add one registry record, implement any supported operation
+  handlers in `src/lib/package_manager.sh`, and extend the registry tests and
+  this table. Registry operation fields are handler identifiers and are never
+  evaluated as shell input.
 x_pages:
   title: LCT
   tagline: Local configuration tool

--- a/src/commands/pages/pages.yml
+++ b/src/commands/pages/pages.yml
@@ -318,6 +318,21 @@ commands:
               `bootstrap_order` controls the sequence used by `lct bootstrap`. The default order is `packages`, `configs`, `projects`, `plugins`, `modules`, then `secrets`.
 
               Custom orders must include every supported phase exactly once. LCT validates the list and prints the resolved order before running any phase.
+          - title: Package-manager model
+            content: |
+              LCT keeps package-manager metadata in an internal registry. The registry distinguishes `system`, `runtime`, and `language` managers, records typed dependencies such as `runtime:node`, and marks unavailable bundle operations as `unsupported`.
+
+              | Manager | Category | Dependencies | Install/remove | Bundle export/restore |
+              | --- | --- | --- | --- | --- |
+              | `brew` | system | none | supported | supported |
+              | `apt` | system | none | supported | supported |
+              | `mise` | runtime | none | supported | supported |
+              | `pnpm` | language | `runtime:node` | supported | unsupported |
+              | `cargo` | language | `runtime:rust` | supported | unsupported |
+              | `pip` | language | `runtime:python` | supported | supported |
+              | `uv` | language | none | supported | unsupported |
+
+              To add a manager, add one registry record, implement any supported operation handlers in `src/lib/package_manager.sh`, and extend the registry tests and this table. Registry operation fields are handler identifiers and are never evaluated as shell input.
       - name: environment-variables
         help: Environment variables that control LCT behavior.
         x_sections:

--- a/src/lib/package_manager.sh
+++ b/src/lib/package_manager.sh
@@ -90,9 +90,15 @@ _lct_record_package() {
 _lct_install_library() {
   local manager="$1"
   local package="$2"
-  local target bin_dir
+  local target bin_dir install_handler
 
-  case "$manager" in
+  install_handler="$(_lct_package_manager_get "$manager" install_handler 2>/dev/null || true)"
+  if [[ -z "$install_handler" || "$install_handler" == "unsupported" ]]; then
+    printf "Unsupported package manager: %s\n" "$manager" >&2
+    return 1
+  fi
+
+  case "$install_handler" in
   brew)
     brew install "$package" &&
       brew bundle add "$package" --file="$LCT_BREW_FILE"
@@ -192,9 +198,15 @@ _lct_install_library() {
 _lct_remove_library() {
   local manager="$1"
   local package="$2"
-  local target
+  local target remove_handler
 
-  case "$manager" in
+  remove_handler="$(_lct_package_manager_get "$manager" remove_handler 2>/dev/null || true)"
+  if [[ -z "$remove_handler" || "$remove_handler" == "unsupported" ]]; then
+    printf "Unsupported package manager: %s\n" "$manager" >&2
+    return 1
+  fi
+
+  case "$remove_handler" in
   brew)
     brew uninstall "$package" &&
       brew bundle remove "$package" --file="$LCT_BREW_FILE"
@@ -289,61 +301,45 @@ _lct_remove_library() {
 
 _lct_package_bundle_filename() {
   local manager="$1"
-  case "$manager" in
-  brew) echo "Brewfile" ;;
-  pip) echo "requirements.txt" ;;
-  winget) echo "winget-packages.json" ;;
-  mise) echo "mise-packages.txt" ;;
-  nix) echo "nix-packages.txt" ;;
-  apt) echo "apt-packages.txt" ;;
-  dnf) echo "dnf-packages.txt" ;;
-  yum) echo "yum-packages.txt" ;;
-  zypper) echo "zypper-packages.txt" ;;
-  pacman) echo "pacman-packages.txt" ;;
-  aur) echo "aur-packages.txt" ;;
-  pkg) echo "pkg-packages.txt" ;;
-  *) echo "${manager}.packages" ;;
-  esac
+  local bundle_filename
+
+  bundle_filename="$(_lct_package_manager_get "$manager" bundle_filename 2>/dev/null || true)"
+  if [[ -z "$bundle_filename" || "$bundle_filename" == "unsupported" ]]; then
+    echo "${manager}.packages"
+  else
+    echo "$bundle_filename"
+  fi
 }
 
 _lct_package_bundle_known_files() {
-  cat <<'EOF'
-Brewfile
-requirements.txt
-packages.txt
-apt-packages.txt
-dnf-packages.txt
-yum-packages.txt
-zypper-packages.txt
-pacman-packages.txt
-aur-packages.txt
-pkg-packages.txt
-winget-packages.json
-mise-packages.txt
-nix-packages.txt
-EOF
+  local manager
+
+  while IFS= read -r manager; do
+    _lct_package_bundle_filename "$manager"
+  done < <(_lct_package_bundle_managers)
+
+  # Kept for compatibility with repositories produced by older LCT releases.
+  echo "packages.txt"
 }
 
 _lct_package_bundle_managers() {
-  cat <<'EOF'
-brew
-pip
-apt
-dnf
-yum
-zypper
-pacman
-aur
-pkg
-winget
-mise
-nix
-EOF
+  local manager export_handler restore_handler
+
+  while IFS= read -r manager; do
+    export_handler="$(_lct_package_manager_get "$manager" export_handler)" || continue
+    restore_handler="$(_lct_package_manager_get "$manager" restore_handler)" || continue
+    [[ "$export_handler" != "unsupported" && "$restore_handler" != "unsupported" ]] || continue
+    printf '%s\n' "$manager"
+  done < <(_lct_package_manager_names)
 }
 
 _lct_can_dump_package_bundle() {
   local manager="$1"
-  case "$manager" in
+  local export_handler
+
+  export_handler="$(_lct_package_manager_get "$manager" export_handler 2>/dev/null || true)"
+  [[ -n "$export_handler" && "$export_handler" != "unsupported" ]] || return 1
+  case "$export_handler" in
   brew) command -v brew >/dev/null 2>&1 ;;
   pip) command -v python >/dev/null 2>&1 || command -v pip >/dev/null 2>&1 ;;
   apt) command -v dpkg >/dev/null 2>&1 ;;
@@ -362,7 +358,11 @@ _lct_can_dump_package_bundle() {
 
 _lct_can_install_package_bundle() {
   local manager="$1"
-  case "$manager" in
+  local restore_handler
+
+  restore_handler="$(_lct_package_manager_get "$manager" restore_handler 2>/dev/null || true)"
+  [[ -n "$restore_handler" && "$restore_handler" != "unsupported" ]] || return 1
+  case "$restore_handler" in
   brew) command -v brew >/dev/null 2>&1 ;;
   pip) command -v python >/dev/null 2>&1 || command -v pip >/dev/null 2>&1 ;;
   apt) command -v apt-get >/dev/null 2>&1 ;;
@@ -387,11 +387,14 @@ _lct_read_bundle_packages() {
 _lct_install_package_bundle_from_file() {
   local manager="$1"
   local bundle_file="$2"
+  local restore_handler
   local -a packages=()
 
   [[ -f "$bundle_file" ]] || return 1
+  restore_handler="$(_lct_package_manager_get "$manager" restore_handler 2>/dev/null || true)"
+  [[ -n "$restore_handler" && "$restore_handler" != "unsupported" ]] || return 1
 
-  case "$manager" in
+  case "$restore_handler" in
   brew)
     brew bundle --file "$bundle_file"
     ;;
@@ -407,7 +410,7 @@ _lct_install_package_bundle_from_file() {
     if [[ ${#packages[@]} -eq 0 ]]; then
       return 0
     fi
-    case "$manager" in
+    case "$restore_handler" in
     apt) apt-get install -y "${packages[@]}" ;;
     dnf) dnf install -y "${packages[@]}" ;;
     yum) yum install -y "${packages[@]}" ;;
@@ -508,8 +511,12 @@ _lct_install_gathered_package_bundle() {
 _lct_dump_package_bundle() {
   local manager="$1"
   local output_file="$2"
+  local export_handler
 
-  case "$manager" in
+  export_handler="$(_lct_package_manager_get "$manager" export_handler 2>/dev/null || true)"
+  [[ -n "$export_handler" && "$export_handler" != "unsupported" ]] || return 1
+
+  case "$export_handler" in
   brew)
     HOMEBREW_NO_AUTO_UPDATE=1 \
       HOMEBREW_NO_INSTALL_CLEANUP=1 \

--- a/src/lib/package_manager.sh
+++ b/src/lib/package_manager.sh
@@ -536,9 +536,9 @@ _lct_dump_package_bundle() {
   dnf | yum | zypper)
     if command -v rpm >/dev/null 2>&1; then
       rpm -qa --qf '%{NAME}\n' | sort -u >"$output_file"
-    elif [[ "$manager" == "dnf" ]]; then
+    elif [[ "$export_handler" == "dnf" ]]; then
       dnf list installed >"$output_file"
-    elif [[ "$manager" == "yum" ]]; then
+    elif [[ "$export_handler" == "yum" ]]; then
       yum list installed >"$output_file"
     else
       zypper search --installed-only >"$output_file"

--- a/src/lib/package_manager_registry.sh
+++ b/src/lib/package_manager_registry.sh
@@ -109,10 +109,26 @@ _lct_validate_package_manager_registry() {
     *) return 1 ;;
     esac
     [[ "$detect_commands" =~ ^[a-z0-9][a-z0-9,-]*$ ]] || return 1
-    [[ "$install_handler" =~ ^[a-z0-9][a-z0-9-]*$ ]] || return 1
-    [[ "$remove_handler" =~ ^[a-z0-9][a-z0-9-]*$ ]] || return 1
-    [[ "$export_handler" == "unsupported" || "$export_handler" =~ ^[a-z0-9][a-z0-9-]*$ ]] || return 1
-    [[ "$restore_handler" == "unsupported" || "$restore_handler" =~ ^[a-z0-9][a-z0-9-]*$ ]] || return 1
+
+    case "$install_handler" in
+    brew|apt|dnf|yum|zypper|pacman|aur|nix|asdf|flox|npm|pnpm|yarn|bun|cargo|cargo-binstall|pip|uv|gem|go|composer|winget|scoop|pkg|mise) ;;
+    *) return 1 ;;
+    esac
+
+    case "$remove_handler" in
+    brew|apt|dnf|yum|zypper|pacman|aur|nix|asdf|flox|npm|pnpm|yarn|bun|cargo|cargo-binstall|pip|uv|gem|go|composer|winget|scoop|pkg|mise) ;;
+    *) return 1 ;;
+    esac
+
+    case "$export_handler" in
+    unsupported|brew|pip|apt|dnf|yum|zypper|pacman|aur|nix|winget|pkg|mise) ;;
+    *) return 1 ;;
+    esac
+
+    case "$restore_handler" in
+    unsupported|brew|pip|apt|dnf|yum|zypper|pacman|aur|nix|winget|pkg|mise) ;;
+    *) return 1 ;;
+    esac
 
     if [[ "$export_handler" == "unsupported" || "$restore_handler" == "unsupported" ]]; then
       [[ "$export_handler" == "unsupported" && "$restore_handler" == "unsupported" ]] || return 1

--- a/src/lib/package_manager_registry.sh
+++ b/src/lib/package_manager_registry.sh
@@ -1,0 +1,150 @@
+# Package manager registry fields:
+# name|category|dependencies|detect_commands|install_handler|remove_handler|export_handler|restore_handler|bundle_filename
+#
+# Dependencies use typed identifiers (`manager:<name>` or `runtime:<name>`).
+# Operation handlers are identifiers dispatched by package_manager.sh; they are
+# never evaluated as shell input. `unsupported` records an intentional gap.
+_lct_package_manager_registry() {
+  cat <<'EOF'
+brew|system|none|brew|brew|brew|brew|brew|Brewfile
+pip|language|runtime:python|python,pip|pip|pip|pip|pip|requirements.txt
+apt|system|none|apt-get,dpkg-query|apt|apt|apt|apt|apt-packages.txt
+dnf|system|none|dnf|dnf|dnf|dnf|dnf|dnf-packages.txt
+yum|system|none|yum|yum|yum|yum|yum|yum-packages.txt
+zypper|system|none|zypper|zypper|zypper|zypper|zypper|zypper-packages.txt
+pacman|system|none|pacman|pacman|pacman|pacman|pacman|pacman-packages.txt
+aur|system|manager:pacman|paru,yay|aur|aur|aur|aur|aur-packages.txt
+pkg|system|none|pkg|pkg|pkg|pkg|pkg|pkg-packages.txt
+winget|system|none|winget|winget|winget|winget|winget|winget-packages.json
+mise|runtime|none|mise|mise|mise|mise|mise|mise-packages.txt
+nix|system|none|nix-env|nix|nix|nix|nix|nix-packages.txt
+asdf|runtime|none|asdf|asdf|asdf|unsupported|unsupported|unsupported
+flox|runtime|none|flox|flox|flox|unsupported|unsupported|unsupported
+npm|language|runtime:node|npm|npm|npm|unsupported|unsupported|unsupported
+pnpm|language|runtime:node|pnpm|pnpm|pnpm|unsupported|unsupported|unsupported
+yarn|language|runtime:node|yarn|yarn|yarn|unsupported|unsupported|unsupported
+bun|language|none|bun|bun|bun|unsupported|unsupported|unsupported
+cargo|language|runtime:rust|cargo|cargo|cargo|unsupported|unsupported|unsupported
+cargo-binstall|language|manager:cargo|cargo-binstall|cargo-binstall|cargo-binstall|unsupported|unsupported|unsupported
+uv|language|none|uv|uv|uv|unsupported|unsupported|unsupported
+gem|language|runtime:ruby|gem|gem|gem|unsupported|unsupported|unsupported
+go|language|runtime:go|go|go|go|unsupported|unsupported|unsupported
+composer|language|runtime:php|composer|composer|composer|unsupported|unsupported|unsupported
+scoop|system|none|scoop|scoop|scoop|unsupported|unsupported|unsupported
+EOF
+}
+
+_lct_package_manager_get() {
+  local requested_manager="$1"
+  local requested_field="$2"
+  local name category dependencies detect_commands install_handler remove_handler
+  local export_handler restore_handler bundle_filename
+
+  case "$requested_field" in
+  name | category | dependencies | detect_commands | install_handler | remove_handler | export_handler | restore_handler | bundle_filename) ;;
+  *) return 1 ;;
+  esac
+
+  while IFS='|' read -r name category dependencies detect_commands install_handler remove_handler export_handler restore_handler bundle_filename; do
+    [[ "$name" == "$requested_manager" ]] || continue
+    case "$requested_field" in
+    name) printf '%s\n' "$name" ;;
+    category) printf '%s\n' "$category" ;;
+    dependencies) printf '%s\n' "$dependencies" ;;
+    detect_commands) printf '%s\n' "$detect_commands" ;;
+    install_handler) printf '%s\n' "$install_handler" ;;
+    remove_handler) printf '%s\n' "$remove_handler" ;;
+    export_handler) printf '%s\n' "$export_handler" ;;
+    restore_handler) printf '%s\n' "$restore_handler" ;;
+    bundle_filename) printf '%s\n' "$bundle_filename" ;;
+    esac
+    return 0
+  done < <(_lct_package_manager_registry)
+
+  return 1
+}
+
+_lct_package_manager_known() {
+  _lct_package_manager_get "$1" name >/dev/null 2>&1
+}
+
+_lct_package_manager_names() {
+  local requested_category="${1:-}"
+  local name category dependencies detect_commands install_handler remove_handler
+  local export_handler restore_handler bundle_filename
+
+  case "$requested_category" in
+  "" | system | runtime | language) ;;
+  *) return 1 ;;
+  esac
+
+  while IFS='|' read -r name category dependencies detect_commands install_handler remove_handler export_handler restore_handler bundle_filename; do
+    [[ -z "$requested_category" || "$category" == "$requested_category" ]] || continue
+    printf '%s\n' "$name"
+  done < <(_lct_package_manager_registry)
+}
+
+_lct_package_manager_dependencies() {
+  local dependencies dependency
+  local -a dependency_items=()
+
+  dependencies="$(_lct_package_manager_get "$1" dependencies)" || return 1
+  [[ "$dependencies" != "none" ]] || return 0
+
+  IFS=',' read -r -a dependency_items <<<"$dependencies"
+  for dependency in "${dependency_items[@]}"; do
+    printf '%s\n' "$dependency"
+  done
+}
+
+_lct_validate_package_manager_registry() {
+  local name category dependencies detect_commands install_handler remove_handler
+  local export_handler restore_handler bundle_filename existing dependency dependency_type dependency_name
+  local -a names=() dependency_items=()
+
+  while IFS='|' read -r name category dependencies detect_commands install_handler remove_handler export_handler restore_handler bundle_filename; do
+    [[ "$name" =~ ^[a-z0-9][a-z0-9-]*$ ]] || return 1
+    case "$category" in
+    system | runtime | language) ;;
+    *) return 1 ;;
+    esac
+    [[ "$detect_commands" =~ ^[a-z0-9][a-z0-9,-]*$ ]] || return 1
+    [[ "$install_handler" =~ ^[a-z0-9][a-z0-9-]*$ ]] || return 1
+    [[ "$remove_handler" =~ ^[a-z0-9][a-z0-9-]*$ ]] || return 1
+    [[ "$export_handler" == "unsupported" || "$export_handler" =~ ^[a-z0-9][a-z0-9-]*$ ]] || return 1
+    [[ "$restore_handler" == "unsupported" || "$restore_handler" =~ ^[a-z0-9][a-z0-9-]*$ ]] || return 1
+
+    if [[ "$export_handler" == "unsupported" || "$restore_handler" == "unsupported" ]]; then
+      [[ "$export_handler" == "unsupported" && "$restore_handler" == "unsupported" ]] || return 1
+      [[ "$bundle_filename" == "unsupported" ]] || return 1
+    else
+      [[ "$bundle_filename" != "unsupported" && -n "$bundle_filename" ]] || return 1
+    fi
+
+    for existing in "${names[@]}"; do
+      [[ "$existing" != "$name" ]] || return 1
+    done
+    names+=("$name")
+  done < <(_lct_package_manager_registry)
+
+  ((${#names[@]} > 0)) || return 1
+
+  while IFS='|' read -r name category dependencies detect_commands install_handler remove_handler export_handler restore_handler bundle_filename; do
+    [[ "$dependencies" != "none" ]] || continue
+    IFS=',' read -r -a dependency_items <<<"$dependencies"
+    for dependency in "${dependency_items[@]}"; do
+      dependency_type="${dependency%%:*}"
+      dependency_name="${dependency#*:}"
+      [[ -n "$dependency_name" && "$dependency_name" != "$dependency" ]] || return 1
+      case "$dependency_type" in
+      runtime)
+        [[ "$dependency_name" =~ ^[a-z0-9][a-z0-9-]*$ ]] || return 1
+        ;;
+      manager)
+        _lct_package_manager_known "$dependency_name" || return 1
+        ;;
+      *) return 1 ;;
+      esac
+    done
+  done < <(_lct_package_manager_registry)
+}

--- a/test/package_manager_registry_spec.sh
+++ b/test/package_manager_registry_spec.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(dirname "$0")/approvals.bash"
+source "$(dirname "$0")/../src/lib/package_manager_registry.sh"
+source "$(dirname "$0")/../src/lib/package_manager.sh"
+
+describe "package manager registry"
+
+assert_equal() {
+  local expected="$1"
+  local actual="$2"
+  local description="$3"
+
+  if [[ "$actual" == "$expected" ]]; then
+    pass "$description"
+  else
+    fail "$description (expected '$expected', got '$actual')"
+  fi
+}
+
+it "validates the complete registry"
+_lct_validate_package_manager_registry
+pass "registry is valid"
+
+it "rejects duplicate manager names"
+(
+  _lct_package_manager_registry() {
+    cat <<'EOF'
+demo|system|none|demo|demo|demo|unsupported|unsupported|unsupported
+demo|runtime|none|demo|demo|demo|unsupported|unsupported|unsupported
+EOF
+  }
+
+  if _lct_validate_package_manager_registry; then
+    fail "duplicate manager names were accepted"
+  else
+    pass "duplicate manager names are rejected"
+  fi
+)
+
+it "rejects invalid manager categories"
+(
+  _lct_package_manager_registry() {
+    cat <<'EOF'
+demo|unknown|none|demo|demo|demo|unsupported|unsupported|unsupported
+EOF
+  }
+
+  if _lct_validate_package_manager_registry; then
+    fail "invalid manager category was accepted"
+  else
+    pass "invalid manager category is rejected"
+  fi
+)
+
+it "rejects unknown manager dependencies"
+(
+  _lct_package_manager_registry() {
+    cat <<'EOF'
+demo|language|manager:missing|demo|demo|demo|unsupported|unsupported|unsupported
+EOF
+  }
+
+  if _lct_validate_package_manager_registry; then
+    fail "unknown manager dependency was accepted"
+  else
+    pass "unknown manager dependency is rejected"
+  fi
+)
+
+it "classifies required managers"
+assert_equal "system" "$(_lct_package_manager_get brew category)" "brew is a system manager"
+assert_equal "system" "$(_lct_package_manager_get apt category)" "apt is a system manager"
+assert_equal "runtime" "$(_lct_package_manager_get mise category)" "mise is a runtime manager"
+for manager in pnpm cargo pip uv; do
+  assert_equal "language" "$(_lct_package_manager_get "$manager" category)" "$manager is a language manager"
+done
+
+it "represents runtime dependencies"
+assert_equal "runtime:node" "$(_lct_package_manager_get pnpm dependencies)" "pnpm depends on Node"
+assert_equal "runtime:rust" "$(_lct_package_manager_get cargo dependencies)" "cargo depends on Rust"
+assert_equal "runtime:python" "$(_lct_package_manager_get pip dependencies)" "pip depends on Python"
+
+it "represents supported and unsupported package bundle operations"
+assert_equal "pip" "$(_lct_package_manager_get pip export_handler)" "pip export is supported"
+assert_equal "pip" "$(_lct_package_manager_get pip restore_handler)" "pip restore is supported"
+for manager in pnpm cargo uv; do
+  assert_equal "unsupported" "$(_lct_package_manager_get "$manager" export_handler)" "$manager export is unsupported"
+  assert_equal "unsupported" "$(_lct_package_manager_get "$manager" restore_handler)" "$manager restore is unsupported"
+done
+
+it "registers every package manager with an install handler"
+expected_managers="apt
+asdf
+aur
+brew
+bun
+cargo
+cargo-binstall
+composer
+dnf
+flox
+gem
+go
+mise
+nix
+npm
+pacman
+pip
+pkg
+pnpm
+scoop
+uv
+winget
+yarn
+yum
+zypper"
+actual_managers="$(_lct_package_manager_names | sort)"
+assert_equal "$expected_managers" "$actual_managers" "all existing managers are registered"
+
+while IFS= read -r manager; do
+  [[ -n "$manager" ]] || continue
+  if [[ "$(_lct_package_manager_get "$manager" install_handler)" == "unsupported" ]]; then
+    fail "$manager has no install handler"
+  fi
+done < <(_lct_package_manager_names)
+pass "all registered managers have install handlers"
+
+it "rejects unknown managers and fields"
+if _lct_package_manager_known unknown; then
+  fail "unknown manager was accepted"
+else
+  pass "unknown manager is rejected"
+fi
+
+if _lct_package_manager_get brew unknown_field >/dev/null 2>&1; then
+  fail "unknown field was accepted"
+else
+  pass "unknown field is rejected"
+fi
+
+it "preserves the existing bundle manager set and filenames"
+expected_bundle_managers="brew
+pip
+apt
+dnf
+yum
+zypper
+pacman
+aur
+pkg
+winget
+mise
+nix"
+assert_equal "$expected_bundle_managers" "$(_lct_package_bundle_managers)" "bundle manager discovery is unchanged"
+assert_equal "Brewfile" "$(_lct_package_bundle_filename brew)" "brew bundle filename is unchanged"
+assert_equal "requirements.txt" "$(_lct_package_bundle_filename pip)" "pip bundle filename is unchanged"
+assert_equal "mise-packages.txt" "$(_lct_package_bundle_filename mise)" "mise bundle filename is unchanged"
+
+it "drives bundle discovery from registry metadata"
+(
+  _lct_package_manager_registry() {
+    cat <<'EOF'
+demo|system|none|demo|demo|demo|demo|demo|demo-bundle.txt
+future|language|runtime:demo|future|future|future|unsupported|unsupported|unsupported
+EOF
+  }
+
+  assert_equal "demo-bundle.txt" "$(_lct_package_bundle_filename demo)" "bundle filename comes from the registry"
+  assert_equal "demo" "$(_lct_package_bundle_managers)" "only bundle-capable registry managers are discovered"
+)
+
+it "dispatches package operations through registry handlers"
+(
+  _lct_package_manager_registry() {
+    cat <<'EOF'
+demo|system|none|brew|brew|brew|unsupported|unsupported|unsupported
+EOF
+  }
+  brew() {
+    printf 'brew %s\n' "$*"
+  }
+  LCT_SHARE_DIR="$tmpdir/registry-share"
+  LCT_BREW_FILE="$LCT_SHARE_DIR/Brewfile"
+  mkdir -p "$LCT_SHARE_DIR"
+
+  expected_output="brew install ripgrep
+brew bundle add ripgrep --file=$LCT_BREW_FILE"
+  actual_output="$(_lct_install_library demo ripgrep)"
+  assert_equal "$expected_output" "$actual_output" "install handler comes from the registry"
+)
+
+it "dispatches bundle operations through registry handlers"
+(
+  _lct_package_manager_registry() {
+    cat <<'EOF'
+demo|system|none|demo|demo|demo|brew|apt|demo-bundle.txt
+EOF
+  }
+  brew() {
+    printf 'brew %s\n' "$*" >>"$tmpdir/registry-bundle-calls"
+  }
+  apt-get() {
+    printf 'apt-get %s\n' "$*"
+  }
+  bundle_file="$tmpdir/demo-bundle.txt"
+  printf 'ripgrep\nfd-find\n' >"$bundle_file"
+
+  _lct_dump_package_bundle demo "$bundle_file"
+  assert_equal "brew bundle dump --describe --force --file=$bundle_file" "$(cat "$tmpdir/registry-bundle-calls")" "export handler comes from the registry"
+  assert_equal "apt-get install -y ripgrep fd-find" "$(_lct_install_package_bundle_from_file demo "$bundle_file")" "restore handler comes from the registry"
+)


### PR DESCRIPTION
## Summary
- add an internal package-manager registry with typed dependencies and explicit unsupported operations
- route install, remove, bundle export, and bundle restore flows through registry handlers
- document the registry model in README and schema docs
- add tests covering registry validation, dispatch, and bundle discovery

## Testing
- Not run (not requested)